### PR TITLE
Add quiz categories with random mode

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -38,3 +38,10 @@ button {
 button:hover {
   background-color: #c40061;
 }
+
+select {
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  border-radius: 10px;
+  font-size: 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
 <body>
   <div class="container">
     <h1>🧠 What is this?</h1>
+    <label for="category-select">Category:</label>
+    <select id="category-select"></select>
     <img id="quiz-image" src="" alt="Quiz Item" />
     <div id="options" class="options"></div>
     <p id="feedback"></p>

--- a/js/main.js
+++ b/js/main.js
@@ -3,30 +3,68 @@ const quizData = [
   {
     image: "public/images/spanner.jpg",
     correct: "Spanner",
+    category: "Tools",
     options: ["Spanner", "Wrench", "Tweezer", "Hammer"]
   },
   {
     image: "public/images/tampon.jpg",
     correct: "Tampon",
+    category: "Health",
     options: ["Tampon", "Lipstick", "Marker", "Eraser"]
   },
   {
     image: "public/images/lashes.jpg",
     correct: "False Eyelashes",
+    category: "Beauty",
     options: ["False Eyelashes", "Caterpillars", "Hair Extension", "Brush"]
   },
   {
     image: "public/images/diaper.jpg",
     correct: "Diaper",
+    category: "Baby",
     options: ["Diaper", "Bib", "Towel", "Bandage"]
   }
 ];
 
+let currentQuiz = [];
 let currentQuestion = 0;
 
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function populateCategories() {
+  const select = document.getElementById("category-select");
+  const categories = [...new Set(quizData.map(q => q.category))];
+  select.innerHTML = "<option value='All'>All (Random)</option>";
+  categories.forEach(cat => {
+    const opt = document.createElement("option");
+    opt.value = cat;
+    opt.textContent = cat;
+    select.appendChild(opt);
+  });
+}
+
+function setCategory(cat) {
+  if (cat === "All") {
+    currentQuiz = [...quizData];
+  } else {
+    currentQuiz = quizData.filter(q => q.category === cat);
+  }
+  shuffle(currentQuiz);
+  currentQuestion = 0;
+}
+
 function loadQuestion() {
-  const q = quizData[currentQuestion];
-  document.getElementById("quiz-image").src = q.image;
+  if (currentQuiz.length === 0) return;
+  const q = currentQuiz[currentQuestion];
+  const imgEl = document.getElementById("quiz-image");
+  imgEl.src = q.image;
+  imgEl.alt = q.correct;
   const optsDiv = document.getElementById("options");
   optsDiv.innerHTML = "";
   q.options.forEach(opt => {
@@ -41,8 +79,18 @@ function loadQuestion() {
 }
 
 document.getElementById("next-btn").addEventListener("click", () => {
-  currentQuestion = (currentQuestion + 1) % quizData.length;
+  if (currentQuiz.length === 0) return;
+  currentQuestion = (currentQuestion + 1) % currentQuiz.length;
   loadQuestion();
 });
 
-window.onload = loadQuestion;
+document.getElementById("category-select").addEventListener("change", e => {
+  setCategory(e.target.value);
+  loadQuestion();
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  populateCategories();
+  setCategory("All");
+  loadQuestion();
+});


### PR DESCRIPTION
## Summary
- add dropdown in index.html to select category
- style select element
- store quiz categories in data and implement filtering
- add random mode when choosing 'All'
- shuffle questions for every category and set image alt to answer
- initialize using DOMContentLoaded

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6888298e7e4083239b09ab605b7b2db8